### PR TITLE
Release/1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # TwitchGetEvents
 [![Build Status](https://travis-ci.org/Lund-Org/twitch-get-events.svg?branch=master)](https://travis-ci.org/Lund-Org/twitch-get-events)
-The module to get the events of a Twitch channel ('cause there is no API for it)
+
+The module to get the events of a Twitch channel ('cause there is no doc for it)
 
 ## :fast_forward: Getting Started
 
@@ -18,6 +19,8 @@ If you don't have Docker, you need `node >= 9` and `npm >= 6`
 
 - [Docker](https://www.docker.com/)
 - [Node & npm](https://nodejs.org/en/)
+
+You need a "client-id" from twitch too. To achieve it, you need to create an application [here](https://glass.twitch.tv/console/apps), then when you want to manage it, you will find a client identifier.
 
 ### :arrow_forward: Installing
 
@@ -40,7 +43,6 @@ For Node/Npm users :
       npm install
       npm run dev
 
-:warning: **CAREFUL, THE LOCAL MODE DOESN'T WORK ON WINDOWS** (puppeteer errors :sob: )
 
 ## :arrows_counterclockwise: Running the tests
 
@@ -64,12 +66,12 @@ For Node/Npm users :
 
 ## :arrow_up: Deployment
 
-The package will be available on npm, need a link
+The package is build by Travis and is available [here](https://www.npmjs.com/package/@lund-org/twitch-events)
 
 ## :arrow_heading_down: Built With
 
-* [Puppeteer](https://github.com/GoogleChrome/puppeteer) - Headless Chrome Node API
 * [Hapi](https://github.com/hapijs/hapi) (for demo purpose) - Server Framework for Node.js
+* [Twith GQL API](https://dev.twitch.tv/) - The twitch dev portal
 
 ## :cool: Contributing
 

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -9,37 +9,4 @@ COPY ./.eslintrc.js /opt/app/
 
 RUN chmod a+x /var/scripts/*
 
-### As describe here : https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md ###
-
-# See https://crbug.com/795759
-RUN apt-get update && apt-get -yq upgrade && apt-get install -yq libgconf-2-4
-
-# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
-# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
-# installs, work.
-RUN apt-get update && apt-get install -y wget --no-install-recommends \
-  && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-  && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-  && apt-get update \
-  && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
-  --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && apt-get purge --auto-remove -y curl \
-  && rm -rf /src/*.deb
-
-# It's a good idea to use dumb-init to help prevent zombie chrome processes.
-ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
-RUN chmod +x /usr/local/bin/dumb-init
-
-# Add user so we don't need --no-sandbox.
-RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
-  && mkdir -p /home/pptruser/Downloads \
-  && chown -R pptruser:pptruser /home/pptruser \
-  && chown -R pptruser:pptruser /opt/app
-
-# Run everything after as non-privileged user.
-USER pptruser
-
 EXPOSE 3000
-
-ENTRYPOINT ["dumb-init", "--"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lund-org/twitch-events",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -35,14 +35,6 @@
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
-      }
-    },
-    "agent-base": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
-      "requires": {
-        "es6-promisify": "^5.0.0"
       }
     },
     "ajv": {
@@ -126,11 +118,6 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
-    },
     "b64": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/b64/-/b64-4.0.0.tgz",
@@ -148,36 +135,11 @@
         "js-tokens": "^3.0.2"
       }
     },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        }
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "big-time": {
       "version": "2.0.1",
@@ -214,6 +176,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -228,7 +191,8 @@
     "buffer-from": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -391,12 +355,14 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -419,15 +385,11 @@
         "boom": "7.x.x"
       }
     },
-    "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -453,6 +415,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -523,19 +486,6 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "es6-promise": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
       }
     },
     "escape-string-regexp": {
@@ -840,17 +790,6 @@
         "tmp": "^0.0.33"
       }
     },
-    "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
-      "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
-      }
-    },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
@@ -868,14 +807,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "requires": {
-        "pend": "~1.2.0"
-      }
     },
     "figures": {
       "version": "2.0.0",
@@ -920,7 +851,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -944,6 +876,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1065,25 +998,6 @@
       "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
       "dev": true
     },
-    "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-      "requires": {
-        "agent-base": "^4.1.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "iconv-lite": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
@@ -1109,6 +1023,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1117,7 +1032,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "inquirer": {
       "version": "3.3.0",
@@ -1264,7 +1180,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isemail": {
       "version": "3.1.2",
@@ -1428,11 +1345,6 @@
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },
-    "mime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
-    },
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
@@ -1459,6 +1371,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1466,12 +1379,14 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -1509,7 +1424,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -1555,6 +1471,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -1630,7 +1547,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -1666,11 +1584,6 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
-    },
-    "pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "pez": {
       "version": "4.0.2",
@@ -1725,17 +1638,14 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
-    },
-    "proxy-from-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -1748,31 +1658,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
-    },
-    "puppeteer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.4.0.tgz",
-      "integrity": "sha512-WDnC1FSHTedvRSS8BZB73tPAx2svUCWFdcxVjrybw8pbKOAB1v5S/pW0EamkqQoL1mXiBc+v8lyYjhhzMHIk1Q==",
-      "requires": {
-        "debug": "^3.1.0",
-        "extract-zip": "^1.6.5",
-        "https-proxy-agent": "^2.1.0",
-        "mime": "^2.0.3",
-        "progress": "^2.0.0",
-        "proxy-from-env": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "ws": "^3.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -1799,6 +1684,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1808,11 +1694,6 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "regexpp": {
       "version": "1.1.0",
@@ -1876,6 +1757,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
       "requires": {
         "glob": "^7.0.5"
       }
@@ -1907,7 +1789,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -2044,6 +1927,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -2208,12 +2092,8 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "underscore": {
       "version": "1.8.3",
@@ -2241,7 +2121,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.3",
@@ -2280,7 +2161,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "wreck": {
       "version": "14.0.2",
@@ -2301,16 +2183,6 @@
         "mkdirp": "^0.5.1"
       }
     },
-    "ws": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-      "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
-      }
-    },
     "xmlcreate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
@@ -2322,14 +2194,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
-    },
-    "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "requires": {
-        "fd-slicer": "~1.0.1"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lund-org/twitch-events",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Retrieve the events from a Twitch Channel",
   "main": "./static/app.js",
   "scripts": {
@@ -25,10 +25,6 @@
     "access": "public"
   },
   "license": "MIT",
-  "dependencies": {
-    "babel-polyfill": "^6.26.0",
-    "puppeteer": "^1.4.0"
-  },
   "devDependencies": {
     "chai": "^4.1.2",
     "docdash": "^0.4.0",

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,13 @@
-const puppeteer = require('puppeteer')
+const https = require('https')
+
+// Privates symbols declaration.
+const _getEvents = Symbol('getEvents')
+const _buildOptions = Symbol('buildOptions')
+const _buildEventData = Symbol('buildEventData')
+const _buildDescriptionData = Symbol('buildDescriptionData')
+const _post = Symbol('post')
+const _handleResponse = Symbol('handleResponse')
+const _formatResponseAsEvents = Symbol('formatResponseAsEvents')
 
 /**
  * Class TwitchEvent.
@@ -7,130 +16,251 @@ const puppeteer = require('puppeteer')
 class TwitchEvent {
   /**
    * Class constructor.
+   * @param {string} clientId - The API twitch clientID.
    * @param {string} username - The twitch username.
    */
-  constructor (username) {
+  constructor (clientId, username) {
+    if (typeof clientId !== 'string') {
+      throw new Error('Error while trying to instanciate TwitchEvent class, "clientId" parameter should be string.')
+    }
     if (typeof username !== 'string') {
       throw new Error('Error while trying to instanciate TwitchEvent class, "username" parameter should be string.')
     }
+    this.clientId = clientId
     this.username = username
   }
 
   /**
    * Method used to extract globals events from twitch user.
    * @param {boolean} [hasDescription=false] - The event description extraction state.
-   * @returns {Array<object>} Representing the globals events list.
+   * @returns {Array} The globals events list.
    */
   getGlobalEvents (hasDescription = false) {
-    return this._getEvents(`https://www.twitch.tv/${this.username}/events`, null, hasDescription)
+    return this[_getEvents]('global', 100, hasDescription)
   }
 
   /**
    * Method used to extract past events from twitch user.
-   * @param {null|number} [offset=null] - Representing the number of events needed.
-   * @param {boolean} [hasDescription=false] - Representing the event description extraction state.
-   * @returns {Array<object>} Representing the past events list.
+   * @param {null|number} [offset=null] - The number of events needed.
+   * @param {boolean} [hasDescription=false] - The event description extraction state.
+   * @returns {Array} The past events list.
    */
   getPastEvents (offset = null, hasDescription = false) {
-    return this._getEvents(`https://www.twitch.tv/${this.username}/events?filter=past`, offset, hasDescription)
+    return this[_getEvents]('past', offset, hasDescription)
   }
 
   /**
-   * Internal private method used to extract needed events.
-   * @param {string} target - Representing the target url.
-   * @param {null|number} offset - Representing the number of events needed.
-   * @param {boolean} hasDescription - Representing the event description extraction state.
-   * @returns {Array<object>} Representing the events list.
+   * Internal private method used to get needed events.
+   * @private
+   * @param {string} type - The events type, can be "past" or "global".
+   * @param {null|number} offset - The number of events needed.
+   * @param {boolean} hasDescription - The event description extraction state.
+   * @returns {Array} The events list.
    */
-  async _getEvents (target, offset, hasDescription) {
-    let events
-
+  async [_getEvents] (type, offset, hasDescription) {
     try {
-      const browser = await puppeteer.launch({
-        headless: true,
-        args: [
-          '--no-sandbox',
-          '--disable-setuid-sandbox'
-        ]
-      })
-      const page = await this._getPage(browser, target)
-      events = await this._extractEvents(page, offset)
-      events = hasDescription ? await this._getDescriptions(browser, events) : events
-      await browser.close()
-    } catch (error) {
-      console.log(error)
+      offset = offset || 20
+
+      const limit = 100
+      const options = this[_buildOptions]()
+      let list = []
+      let count = Number(offset)
+
+      let iterator
+      let eventData
+      let requestResponse
+      let formatted
+
+      do {
+        // Work with iterator to select adjusted amount of events by request.
+        iterator = offset > limit ? limit : offset
+        iterator = iterator > count ? count : iterator
+        count = count - iterator
+
+        eventData = this[_buildEventData](
+          type,
+          iterator,
+          list.length > 0 ? list[list.length - 1].startAt : null
+        )
+
+        requestResponse = await this[_post](options, eventData)
+        formatted = await this[_handleResponse](requestResponse)
+
+        list = list.concat(formatted)
+      } while (count !== 0)
+
+      // If we need event description, we need to send a second request.
+      if (hasDescription) {
+        let descriptionData = []
+
+        let eventIndex
+
+        list.forEach((event) => descriptionData.push(this[_buildDescriptionData](event.id)))
+        const descriptions = await this[_post](options, descriptionData)
+
+        for (let i = 0; i < descriptions.length; ++i) {
+          eventIndex = list.findIndex((event) => descriptions[i].data.event.id === event.id)
+          list[eventIndex].description = descriptions[i].data.event.description
+        }
+      }
+
+      return {
+        status: 'success',
+        data: list
+      }
+    } catch (err) {
+      if (err.constructor.name === 'IncomingMessage') {
+        console.error('You probably use an invalid client-id. Please check it.')
+      } else {
+        console.error(err)
+      }
+
+      return {
+        status: 'error',
+        errors: err
+      }
     }
-    return events
   }
 
   /**
-   * Internal private async method used to create new page and goto targeted url.
-   * @param {Browser} browser - Representing the puppeteer browser instance.
-   * @param {string} target - Representing the target url.
-   * @returns {Page} Representing new page instance created by browser (puppeteer).
+   * Private method to build an option object to pass to the request (post).
+   * @private
+   * @returns {object} The builded options object.
    */
-  async _getPage (browser, target) {
-    const page = await browser.newPage()
-    await page.goto(target, { waitUntil: 'networkidle2' })
-    return page
-  }
-
-  /**
-   * Internal private async method used to assign description for each event.
-   * @param {Browser} browser - Representing the puppeteer browser instance.
-   * @param {Array<object>} events - Representing the events list.
-   * @returns {Array<object>} Representing the updated events list.
-   */
-  async _getDescriptions (browser, events) {
-    for (let i = 0; i < events.length; ++i) {
-      const page = await this._getPage(browser, events[i].link)
-      events[i].description = await this._extractDescription(page)
-      await page.close()
+  [_buildOptions] () {
+    return {
+      protocol: 'https:',
+      method: 'POST',
+      hostname: 'gql.twitch.tv',
+      path: '/gql',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'client-id': this.clientId
+      }
     }
-    return events
   }
 
   /**
-   * Internal private method used to extract events from "virtual page" (DOM scrapping).
-   * @param {Page} page - Representing puppeteer page instance.
-   * @param {null|number} offset - Representing the number of events needed.
-   * @returns {Promise<object>} - Representing events extract from events page.
+   * Private method to build an data object to pass to the request (post).
+   * @private
+   * @param {string} type - Event type, "past" or "global".
+   * @param {number} offset - Number of events needed.
+   * @param {null|date} [date=null] - The events date limit.
+   * @returns {object} The builded data object.
    */
-  _extractEvents (page, offset) {
-    return page.evaluate((offset) => {
-      let formatedEvents = []
-      const visibleEvents = document.querySelectorAll('.tw-c-background.tw-elevation-1 .tw-mg-x-2')
-      const selectedEvents = Array.from(visibleEvents).splice(0, offset || visibleEvents.length)
-      const innerSelector = (target, selector) => target.querySelector(selector).innerText || null
+  [_buildEventData] (type, offset, date = null) {
+    const now = date || new Date()
 
-      // TODO: Load more events. Need to simulate a virtual scrolldown.
+    return [{
+      'operationName': 'EventsPage_EventScheduleQuery',
+      'variables': {
+        'channelLogin': this.username,
+        'limit': typeof offset === 'string' ? parseInt(offset) : offset,
+        'before': type === 'past' ? now : null,
+        'after': type === 'global' ? now : null,
+        'sortOrder': 'DESC',
+        'following': true
+      },
+      'extensions': {
+        'persistedQuery': {
+          'version': 1,
+          'sha256Hash': '1ddc422675ea9d6e7659d54923633fede3a804bfec3b20e3df6ef8eea40d3ea1'
+        }
+      }
+    }]
+  }
 
-      selectedEvents.forEach((selectedEvent) => {
-        const [streamer, game] = innerSelector(selectedEvent, ':nth-child(3n)').split(/ streaming /)
-        formatedEvents.push({
-          link: selectedEvent.querySelector(':nth-child(1n)').href,
-          title: innerSelector(selectedEvent, ':nth-child(1n) h4'),
-          date: innerSelector(selectedEvent, ':nth-child(2n)'),
-          game,
-          streamer
+  [_buildDescriptionData] (eventId) {
+    return {
+      'operationName': 'EventLandingPage_Event',
+      'variables': {
+        'eventName': eventId
+      },
+      'extensions': {
+        'persistedQuery': {
+          'version': 1,
+          'sha256Hash': '4fdc0f4f963f4b9ca046a0638dd5f96643708f49e129d437e48efb8d521cbaa4'
+        }
+      }
+    }
+  }
+
+  /**
+   * Private method to exec https.post request.
+   * @private
+   * @param {object} options - The request options.
+   * @param {object} data - The request post data.
+   * @returns {Promise} The request response.
+   */
+  [_post] (options, data) {
+    return new Promise((resolve, reject) => {
+      const request = https.request(options, (res) => {
+        if (res.statusCode !== 200) {
+          reject(res)
+          return
+        }
+
+        res.setEncoding('utf8')
+
+        let result = ''
+
+        res.on('data', (chunk) => {
+          result += chunk
+        })
+
+        res.on('end', () => {
+          resolve(JSON.parse(result))
         })
       })
-      return formatedEvents
-    }, offset)
+
+      request.on('error', (err) => {
+        reject(err)
+      })
+
+      request.write(JSON.stringify(data))
+      request.end()
+    })
   }
 
   /**
-   * Internal private method used to extract description from linked event page (DOM scrapping).
-   * @param {Page} page - Representing puppeteer page instance.
-   * @returns {Promise<object>} Representing the event description.
+   * Private method to handle post request response.
+   * @private
+   * @param {object} requestResponse - The request response.
+   * @returns {Promise} If resolved, formatted events response, else request error.
    */
-  _extractDescription (page) {
-    return page.evaluate(() => {
-      const description = document.querySelector('.events-landing-collection__main-col')
-        ? document.querySelector('.events-landing-collection__main-col .tw-elevation-2 p span').innerText || null
-        : document.querySelector('.simplebar-scroll-content .tw-flex-grow-1 p span').innerText || null
-      return description
+  [_handleResponse] (requestResponse) {
+    return new Promise((resolve, reject) => {
+      if (requestResponse.errors && requestResponse.errors.length > 0) {
+        reject(requestResponse)
+      } else {
+        resolve(this[_formatResponseAsEvents](requestResponse))
+      }
     })
+  }
+
+  /**
+   * Private method to format request response.
+   * @private
+   * @param {Array} events - The array includes events list.
+   * @returns {Array} The formatted events list.
+   */
+  [_formatResponseAsEvents] (events) {
+    const formatted = []
+
+    events.shift().data.user.eventLeaves.edges.forEach((event) => {
+      event = event.node
+
+      formatted.push({
+        id: event.id,
+        title: event.title,
+        game: event.game.displayName,
+        streamer: event.channel.displayName,
+        startAt: new Date(event.startAt),
+        endAt: new Date(event.endAt)
+      })
+    })
+
+    return formatted
   }
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -12,10 +12,13 @@ const server = new Hapi.Server(Object.assign({
 
 server.route({
   method: 'GET',
-  path: '/global/{username}',
+  path: '/global/{clientId}/{username}',
   handler: async (request, handler) => {
-    const twitchEvent = await new TwitchEvents(encodeURIComponent(request.params.username))
-    return await twitchEvent.getGlobalEvents(
+    const twitchEvent = await new TwitchEvents(
+      encodeURIComponent(request.params.clientId),
+      encodeURIComponent(request.params.username)
+    )
+    return twitchEvent.getGlobalEvents(
       typeof request.query.description !== 'undefined' && request.query.description.toLowerCase() === 'y'
     )
   }
@@ -23,10 +26,13 @@ server.route({
 
 server.route({
   method: 'GET',
-  path: '/past/{username}',
+  path: '/past/{clientId}/{username}',
   handler: async (request, handler) => {
-    const twitchEvent = await new TwitchEvents(encodeURIComponent(request.params.username))
-    return await twitchEvent.getPastEvents(
+    const twitchEvent = await new TwitchEvents(
+      encodeURIComponent(request.params.clientId),
+      encodeURIComponent(request.params.username)
+    )
+    return twitchEvent.getPastEvents(
       typeof request.query.offset === 'string' && request.query.offset.match(/[0-9]+/)
         ? request.query.offset
         : null,

--- a/test/specs/src/main.spec.js
+++ b/test/specs/src/main.spec.js
@@ -1,131 +1,67 @@
 /* global describe it */
 /* eslint valid-typeof: 0 */
 const assert = require('chai').assert
-const puppeteer = require('puppeteer')
 const TwitchEvent = require('../../../src/main.js')
 
 const expectedEvents = [
-  { name: 'link', type: 'string', required: true },
+  { name: 'id', type: 'string', required: true },
   { name: 'title', type: 'string', required: true },
-  { name: 'date', type: 'string', required: true },
+  { name: 'startAt', instance: Date, required: true },
+  { name: 'endAt', instance: Date, required: true },
   { name: 'game', type: 'string', required: true },
   { name: 'streamer', type: 'string', required: true },
   { name: 'description', type: 'string', required: false }
 ]
 
 const testProperties = function (ev) {
-  let error = false
-
   for (let i = 0; i < expectedEvents.length; ++i) {
     let expectedEvent = expectedEvents[i]
     let propertyValue = ev[expectedEvent.name]
     let hasExpectedProperty = ev.hasOwnProperty(expectedEvent.name)
-    if ((expectedEvent.required && (!hasExpectedProperty || propertyValue.trim() === '')) ||
-      (hasExpectedProperty && typeof propertyValue !== expectedEvent.type)) {
-      error = true
-      break
+
+    let isEmptyString = typeof propertyValue === 'string' && propertyValue.trim() === ''
+    let isInvalidType = expectedEvent.hasOwnProperty('type') && hasExpectedProperty && typeof propertyValue !== expectedEvent.type
+    let isInvalidInstance = expectedEvent.hasOwnProperty('instance') && hasExpectedProperty && ev.instance instanceof expectedEvent.instance
+
+    if ((expectedEvent.required && (!hasExpectedProperty || isEmptyString)) || isInvalidType || isInvalidInstance) {
+      return true
     }
   }
 
-  return error
+  return false
 }
 
-const testsEvents = function (events) {
-  assert.isTrue(Array.isArray(events))
-  events.forEach((ev) => {
-    assert.isFalse(testProperties(ev))
-  })
+const testsEvents = function (events, hasDescription = false) {
+  assert.isTrue(Array.isArray(events.data))
+  events.data.forEach((ev) => assert.isFalse(testProperties(ev)))
+
+  if (hasDescription) {
+    events.data.forEach((ev) => assert.isTrue(ev.hasOwnProperty('description')))
+  }
 }
 
-const twitchEvent = new TwitchEvent('lundprod')
+const twitchEvent = new TwitchEvent('heyyiw4txxbrmypyhje24wehmw0qw5', 'lundprod')
 
 describe('Public : TwitchEvent class validity tests', function () {
   it('Test Public: TwitchEvent.getGlobalEvents(false)', async function () {
-    this.timeout(10000)
     const events = await twitchEvent.getGlobalEvents(false)
     testsEvents(events)
   })
 
   it('Test Public: TwitchEvent.getGlobalEvents(true)', async function () {
-    this.timeout(100000)
     const events = await twitchEvent.getGlobalEvents(true)
-    testsEvents(events)
+    testsEvents(events, true)
   })
 
   it('Test Public: TwitchEvent.getPastEvents(3, false)', async function () {
-    this.timeout(10000)
     const events = await twitchEvent.getPastEvents(3, false)
+    assert.isTrue(events.data.length === 3)
     testsEvents(events)
   })
 
   it('Test Public: TwitchEvent.getPastEvents(3, true)', async function () {
-    this.timeout(25000)
     const events = await twitchEvent.getPastEvents(3, true)
-    testsEvents(events)
-  })
-})
-
-describe('Private : TwitchEvent class validity tests', function () {
-  const createBrowser = function () {
-    const browser = puppeteer.launch({
-      headless: true,
-      args: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox'
-      ]
-    })
-    return browser
-  }
-
-  it('Test Private: TwitchEvent._getPage(browser, target)', async function () {
-    this.timeout(10000)
-    const browser = await createBrowser()
-    const page = await twitchEvent._getPage(browser, 'https://google.com')
-    assert.isTrue(typeof page === 'object' && page.constructor.name === 'Page')
-    await browser.close()
-  })
-
-  it('Test Private: TwitchEvent._getDescriptions(browser, events)', async function () {
-    this.timeout(25000)
-    const browser = await createBrowser()
-    let events = await twitchEvent.getPastEvents(3, false)
-    events = await twitchEvent._getDescriptions(browser, events)
-    const errors = events.map((ev) => typeof ev.description === 'string')
-    assert.isFalse(errors.includes(false))
-    await browser.close()
-  })
-
-  it('Test Private: TwitchEvent._extractDescription(page)', async function () {
-    // To reset it after
-    let previousGlobalDocument = global.document
-    // Because it's used in extractDescription
-    global.document = {
-      querySelector: () => {
-        return { innerText: 'Foobar' }
-      }
-    }
-    // Because we don't want to load a full page
-    let pageSimultor = {
-      evaluate: (method) => {
-        return method()
-      }
-    }
-    let events = [{ description: null }]
-
-    events[0].description = await twitchEvent._extractDescription(pageSimultor)
-    const errors = events.map((ev) => typeof ev.description === 'string')
-    assert.isFalse(errors.includes(false))
-    // Reset
-    global.document = previousGlobalDocument
-  })
-
-  it('Test Private: TwitchEvent._extractEvents(page, 3)', async function () {
-    this.timeout(25000)
-    const browser = await createBrowser()
-    const page = await twitchEvent._getPage(browser, 'https://www.twitch.tv/lundprod/events?filter=past')
-    const events = await twitchEvent._extractEvents(page, 3)
-    assert.isTrue(events.length === 3)
-    await testsEvents(events)
-    await browser.close()
+    assert.isTrue(events.data.length === 3)
+    testsEvents(events, true)
   })
 })


### PR DESCRIPTION
* Rewrite TwitchEvent class for version 2.

Rewrite class to use new recovery process, using graphQL api.

Kept 2 public methods getGlobalEvents & getPastEvents
Rewrite getEvents and set it as real private method
Add new buildOptions methods to prepare http request
Add new buildData method to prepare http request
Add new post method to send the request
Add new handleResponse method to handle the request response
Add new formatResponseAsEvents method to convert request response as friendly events object

About the recovery process it can send multiple requests to the API because this one is limited to an event recovery per group of 100

* Updates tests to adapt to new version, remove all private methids test.

* Add feature to get events description, send second request with list of options events needed

* Fix options request management, remove it from loop.

* Optimize the dockerfile, update the Readme and the example

The dockerfile don't need to download chromium anymore.
The readme doesn't need to mention puppeteer now and some twitch
ressources have been added.

* Update version of package.json from 1.0.0 to 1.1.0

* Update README